### PR TITLE
Fix ethereum address comparison to not be case sensitive

### DIFF
--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -155,7 +155,7 @@ class Authenticator extends Authorization
             );
         }
 
-        return $address == $this->pubKeyToAddress($pubkey);
+        return strtolower($address) == strtolower($this->pubKeyToAddress($pubkey));
     }
 
     /**


### PR DESCRIPTION
- There was an issue when generating Eth wallets using web3.js and sending it to this library, because the sent address was capitalized (meaning that is has a checksum), whereas the recovered eth address through `$this->elipticCurve->recoverPubKey` was all lower case.